### PR TITLE
fix case of videos with query parameter

### DIFF
--- a/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
+++ b/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
@@ -132,7 +132,8 @@ extension PhotoManager: URLSessionDownloadDelegate {
             }
         }else {
             let url: URL
-            if key.hasSuffix("mp4") || key.hasSuffix("MP4") {
+            // key.contains("mp4") || key.hasSuffix("MP4"): Consideration of videos with query parameter
+            if key.hasSuffix("mp4") || key.hasSuffix("MP4") || key.contains("mp4") || key.hasSuffix("MP4") {
                 let videoURL = PhotoTools.getVideoCacheURL(for: key)
                 PhotoTools.removeFile(fileURL: videoURL)
                 try? FileManager.default.moveItem(at: location, to: videoURL)

--- a/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
+++ b/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
@@ -133,7 +133,7 @@ extension PhotoManager: URLSessionDownloadDelegate {
         }else {
             let url: URL
             // key.contains("mp4") || key.hasSuffix("MP4"): Consideration of videos with query parameter
-            if key.hasSuffix("mp4") || key.hasSuffix("MP4") || key.contains("mp4") || key.hasSuffix("MP4") {
+            if key.contains("mp4") || key.hasSuffix("MP4") {
                 let videoURL = PhotoTools.getVideoCacheURL(for: key)
                 PhotoTools.removeFile(fileURL: videoURL)
                 try? FileManager.default.moveItem(at: location, to: videoURL)

--- a/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
+++ b/Sources/HXPHPicker/Core/Util/PhotoManager+Download.swift
@@ -132,8 +132,8 @@ extension PhotoManager: URLSessionDownloadDelegate {
             }
         }else {
             let url: URL
-            // key.contains("mp4") || key.hasSuffix("MP4"): Consideration of videos with query parameter
-            if key.contains("mp4") || key.hasSuffix("MP4") {
+            // responseURL.path.hasSuffix("mp4") || responseURL.path.hasSuffix("MP4"): Consideration of videos with query parameter
+            if responseURL.path.hasSuffix("mp4") || responseURL.path.hasSuffix("MP4") {
                 let videoURL = PhotoTools.getVideoCacheURL(for: key)
                 PhotoTools.removeFile(fileURL: videoURL)
                 try? FileManager.default.moveItem(at: location, to: videoURL)


### PR DESCRIPTION
Because the video failed to play when the query parameter was added to the end of the video in NetworkVideoAsset.